### PR TITLE
fix(grpc): update gRPC consumer properties and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ and formatting tools to accelerate development and maintain consistency across p
 <dependency>
     <groupId>box.tapsi.libs</groupId>
     <artifactId>utilities-starter</artifactId>
-    <version>0.9.5</version>
+    <version>0.9.6</version>
 </dependency>
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "box.tapsi.libs"
-version = "0.9.5"
+version = "0.9.6"
 description = "utilities-starter"
 
 repositories {

--- a/src/main/kotlin/box/tapsi/libs/utilities/grpc/consumer/GrpcConsumerProperties.kt
+++ b/src/main/kotlin/box/tapsi/libs/utilities/grpc/consumer/GrpcConsumerProperties.kt
@@ -6,11 +6,10 @@ import java.time.Duration
 @Suppress("detekt.MagicNumber")
 @ConfigurationProperties(prefix = "box.libs.utilities.grpc.consumer")
 data class GrpcConsumerProperties(
-  val enabled: Boolean = true,
+  val enabled: Boolean = false,
   val channels: Map<String, GrpcChannel> = emptyMap(),
   val clients: Map<String, GrpcClient> = emptyMap(),
   val provideDefaultChannels: Boolean = true,
-  val configureChannels: Boolean = true,
 ) {
   data class GrpcChannel(
     val host: String,

--- a/src/main/kotlin/box/tapsi/libs/utilities/grpc/consumer/annotations/OnGrpcClientEnabled.kt
+++ b/src/main/kotlin/box/tapsi/libs/utilities/grpc/consumer/annotations/OnGrpcClientEnabled.kt
@@ -30,7 +30,7 @@ import java.lang.annotation.Inherited
 @ConditionalOnProperty(
   prefix = "box.libs.utilities.grpc.consumer.clients",
   havingValue = "true",
-  matchIfMissing = true,
+  matchIfMissing = false,
 )
 annotation class OnGrpcClientEnabled(
   @get:AliasFor(annotation = ConditionalOnProperty::class)

--- a/src/main/kotlin/box/tapsi/libs/utilities/grpc/consumer/autoconfigure/GrpcChannelRegistrar.kt
+++ b/src/main/kotlin/box/tapsi/libs/utilities/grpc/consumer/autoconfigure/GrpcChannelRegistrar.kt
@@ -21,7 +21,7 @@ class GrpcChannelRegistrar(
   private val createdChannels = ConcurrentHashMap<String, ManagedChannel>()
 
   override fun postProcessBeanDefinitionRegistry(registry: BeanDefinitionRegistry) {
-    props.clients.forEach { (name, _) ->
+    props.channels.forEach { (name, _) ->
       val cfg = GrpcChannelHelper.getGrpcChannelOrMaybeDefault(consumerProperties = props, channelName = name)
       if (registry.containsBeanDefinition(name)) return@forEach
 

--- a/src/main/kotlin/box/tapsi/libs/utilities/grpc/consumer/autoconfigure/GrpcConsumerAutoConfiguration.kt
+++ b/src/main/kotlin/box/tapsi/libs/utilities/grpc/consumer/autoconfigure/GrpcConsumerAutoConfiguration.kt
@@ -22,7 +22,7 @@ import org.springframework.core.env.Environment
   prefix = "box.libs.utilities.grpc.consumer",
   name = ["enabled"],
   havingValue = "true",
-  matchIfMissing = true,
+  matchIfMissing = false,
 )
 class GrpcConsumerAutoConfiguration {
   @Bean
@@ -30,7 +30,7 @@ class GrpcConsumerAutoConfiguration {
     environment: Environment,
     interceptors: List<ClientInterceptor>,
   ): GrpcChannelRegistrar {
-    val props = Binder.get(environment).bind<GrpcConsumerProperties>(
+    val props = Binder.get(environment).bind(
       "box.libs.utilities.grpc.consumer",
       GrpcConsumerProperties::class.java,
     ).orElseThrow {

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -63,18 +63,12 @@
       "name": "box.libs.utilities.grpc.consumer.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether gRPC consumer auto-configuration is enabled.",
-      "defaultValue": true
+      "defaultValue": false
     },
     {
       "name": "box.libs.utilities.grpc.consumer.provide-default-channels",
       "type": "java.lang.Boolean",
       "description": "Whether to provide default channel beans from configured channels.",
-      "defaultValue": true
-    },
-    {
-      "name": "box.libs.utilities.grpc.consumer.configure-channels",
-      "type": "java.lang.Boolean",
-      "description": "Whether to configure managed channel beans.",
       "defaultValue": true
     },
     {

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -150,20 +150,13 @@
       "type": "java.lang.Boolean",
       "sourceType": "box.tapsi.libs.utilities.grpc.consumer.GrpcConsumerProperties",
       "description": "Whether gRPC consumer auto-configuration is enabled.",
-      "defaultValue": true
+      "defaultValue": false
     },
     {
       "name": "box.libs.utilities.grpc.consumer.provide-default-channels",
       "type": "java.lang.Boolean",
       "sourceType": "box.tapsi.libs.utilities.grpc.consumer.GrpcConsumerProperties",
       "description": "Whether to provide default channel beans from configured channels.",
-      "defaultValue": true
-    },
-    {
-      "name": "box.libs.utilities.grpc.consumer.configure-channels",
-      "type": "java.lang.Boolean",
-      "sourceType": "box.tapsi.libs.utilities.grpc.consumer.GrpcConsumerProperties",
-      "description": "Whether to configure managed channel beans.",
       "defaultValue": true
     },
     {


### PR DESCRIPTION
- Set default value of 'enabled' property to false in GrpcConsumerProperties
- Change 'matchIfMissing' to false in OnGrpcClientEnabled and GrpcConsumerAutoConfiguration
- Update configuration metadata to reflect the new default values
- Adjust GrpcChannelRegistrar to iterate over channels instead of clients

These changes ensure that the gRPC consumer is disabled by default, improving control over its activation.